### PR TITLE
loadXML() function not expect non-utf-8 symbols and crash silence

### DIFF
--- a/src/scanner/classes/ScannerController.inc.php
+++ b/src/scanner/classes/ScannerController.inc.php
@@ -54,7 +54,7 @@ class ScannerController
 
         // retrieve list of files and append it to the report
         $tmpXmlDoc = new DOMDocument();
-        $tmpXmlDoc->loadXML('<files>' . $fileScanner->getXMLFilelist() . '</files>');
+        $tmpXmlDoc->loadXML('<files>' . utf8_encode($fileScanner->getXMLFilelist()) . '</files>');
 
         $dom->documentElement->appendChild($dom->importNode($tmpXmlDoc->documentElement, true));
 


### PR DESCRIPTION
Периодически сталкиваемся на хостинге с файлами клиентов, которые имеют в названии не utf-8 символы. Из-за этого в scan_log.xml создаётся пустой список файлов и проверка останавливается на рандомном месте(как только требуется обратиться к этому списку). Данное изменение фиксит эту неприятность.